### PR TITLE
feat: add round amount checkbox

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,9 +4,14 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="TipTimeLayoutPreview">
-        <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2024-10-31T16:46:32.179618Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/carlmonnera/.android/avd/android_15.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/app/src/main/java/com/example/tipcalculator/MainActivity.kt
+++ b/app/src/main/java/com/example/tipcalculator/MainActivity.kt
@@ -4,9 +4,13 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -15,8 +19,10 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -26,6 +32,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
@@ -34,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.tipcalculator.ui.theme.TipCalculatorTheme
 import java.text.NumberFormat
+import kotlin.math.ceil
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -41,7 +49,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             TipCalculatorTheme {
-                Surface {
+                Surface(modifier = Modifier.fillMaxSize()) {
                     TipTimeLayout()
                 }
             }
@@ -49,19 +57,23 @@ class MainActivity : ComponentActivity() {
     }
 }
 
-fun calculateTip(amount: Double, tipPercent: Double = 15.0): String {
+fun calculateTip(amount: Double, tipPercent: Double = 15.0, shouldRoundTip: Boolean): String {
     val tip = tipPercent / 100 * amount
-    return NumberFormat.getCurrencyInstance().format(tip)
+    return NumberFormat.getCurrencyInstance().format(
+        if (shouldRoundTip) ceil(tip).toInt()
+        else tip
+    )
 }
 
 @Composable
 fun TipTimeLayout() {
-    var amount by remember { mutableStateOf("0") }
-    var tipPercent by remember { mutableStateOf("20") }
+    var amount by remember { mutableStateOf("") }
+    var tipPercent by remember { mutableStateOf("") }
+    var shouldRoundTip by remember { mutableStateOf(false) }
 
     val doubleAmount = amount.toDoubleOrNull() ?: 0.0
     val doubleTipPercent = tipPercent.toDoubleOrNull() ?: 0.0
-    val tip = calculateTip(doubleAmount, doubleTipPercent)
+    val tip = calculateTip(doubleAmount, doubleTipPercent, shouldRoundTip)
 
     Column(
         modifier = Modifier
@@ -82,21 +94,38 @@ fun TipTimeLayout() {
                 .align(alignment = Alignment.Start)
         )
         EditNumberField(
-            label = stringResource(R.string.bill_amount),
+            label = R.string.bill_amount,
             amount = amount,
             onValueChange = { amount = it },
+            leadingIcon = R.drawable.money,
             modifier = Modifier
                 .padding(bottom = 32.dp)
                 .fillMaxWidth()
         )
         EditNumberField(
-            label = stringResource(R.string.tip_label),
+            label = R.string.tip_label,
             amount = tipPercent,
             onValueChange = { tipPercent = it },
+            leadingIcon = R.drawable.percent,
             modifier = Modifier
                 .padding(bottom = 32.dp)
                 .fillMaxWidth()
         )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(0.dp, 0.dp, 0.dp, 24.dp)
+        ) {
+            Text("Round up tip?")
+            Switch(
+                checked = shouldRoundTip,
+                onCheckedChange = {
+                    shouldRoundTip = it
+                }
+            )
+        }
         Text(
             text = stringResource(R.string.tip_amount, tip),
             style = MaterialTheme.typography.displaySmall
@@ -107,16 +136,23 @@ fun TipTimeLayout() {
 
 @Composable
 fun EditNumberField(
+    @StringRes label: Int,
+    @DrawableRes leadingIcon: Int,
     modifier: Modifier = Modifier,
-    label: String = "",
     amount: String,
     onValueChange: (str: String) -> Unit
 ) {
     TextField(
+        leadingIcon = {
+            Icon(
+                painter = painterResource(leadingIcon),
+                contentDescription = "TODO"
+            )
+        },
         value = amount,
         onValueChange = onValueChange,
         modifier = modifier,
-        label = { Text(label) },
+        label = { Text(stringResource(label)) },
         singleLine = true,
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
     )

--- a/app/src/main/java/com/example/tipcalculator/MainActivity.kt
+++ b/app/src/main/java/com/example/tipcalculator/MainActivity.kt
@@ -98,6 +98,7 @@ fun TipTimeLayout() {
             amount = amount,
             onValueChange = { amount = it },
             leadingIcon = R.drawable.money,
+            iconDescription = R.string.input_icon_bill_description,
             modifier = Modifier
                 .padding(bottom = 32.dp)
                 .fillMaxWidth()
@@ -107,6 +108,7 @@ fun TipTimeLayout() {
             amount = tipPercent,
             onValueChange = { tipPercent = it },
             leadingIcon = R.drawable.percent,
+            iconDescription = R.string.input_icon_percent_description,
             modifier = Modifier
                 .padding(bottom = 32.dp)
                 .fillMaxWidth()
@@ -118,7 +120,7 @@ fun TipTimeLayout() {
                 .fillMaxWidth()
                 .padding(0.dp, 0.dp, 0.dp, 24.dp)
         ) {
-            Text("Round up tip?")
+            Text(stringResource(R.string.tip_question))
             Switch(
                 checked = shouldRoundTip,
                 onCheckedChange = {
@@ -137,6 +139,7 @@ fun TipTimeLayout() {
 @Composable
 fun EditNumberField(
     @StringRes label: Int,
+    @StringRes iconDescription: Int,
     @DrawableRes leadingIcon: Int,
     modifier: Modifier = Modifier,
     amount: String,
@@ -146,7 +149,7 @@ fun EditNumberField(
         leadingIcon = {
             Icon(
                 painter = painterResource(leadingIcon),
-                contentDescription = "TODO"
+                contentDescription = stringResource(iconDescription)
             )
         },
         value = amount,

--- a/app/src/main/res/drawable/money.xml
+++ b/app/src/main/res/drawable/money.xml
@@ -1,0 +1,22 @@
+<!--
+  ~ Copyright (C) 2023 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M5,8h2v8L5,16zM12,8L9,8c-0.55,0 -1,0.45 -1,1v6c0,0.55 0.45,1 1,1h3c0.55,0 1,-0.45 1,-1L13,9c0,-0.55 -0.45,-1 -1,-1zM11,14h-1v-4h1v4zM18,8h-3c-0.55,0 -1,0.45 -1,1v6c0,0.55 0.45,1 1,1h3c0.55,0 1,-0.45 1,-1L19,9c0,-0.55 -0.45,-1 -1,-1zM17,14h-1v-4h1v4z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M2,4v16h20L22,4L2,4zM4,18L4,6h16v12L4,18z"/>
+</vector>

--- a/app/src/main/res/drawable/percent.xml
+++ b/app/src/main/res/drawable/percent.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright (C) 2023 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M7.5,11C9.43,11 11,9.43 11,7.5S9.43,4 7.5,4S4,5.57 4,7.5S5.57,11 7.5,11zM7.5,6C8.33,6 9,6.67 9,7.5S8.33,9 7.5,9S6,8.33 6,7.5S6.67,6 7.5,6z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M4.0025,18.5831l14.5875,-14.5875l1.4142,1.4142l-14.5875,14.5875z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M16.5,13c-1.93,0 -3.5,1.57 -3.5,3.5s1.57,3.5 3.5,3.5s3.5,-1.57 3.5,-3.5S18.43,13 16.5,13zM16.5,18c-0.83,0 -1.5,-0.67 -1.5,-1.5s0.67,-1.5 1.5,-1.5s1.5,0.67 1.5,1.5S17.33,18 16.5,18z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,7 @@
     <string name="bill_amount">Bill Amount</string>
     <string name="tip_amount">Tip Amount: %s</string>
     <string name="tip_label">Tip %</string>
+    <string name="tip_question">Round up tip?</string>
+    <string name="input_icon_percent_description">Percent icon</string>
+    <string name="input_icon_bill_description">Money icon</string>
 </resources>


### PR DESCRIPTION
Given the [initial app](https://github.com/Fasteel/Tip-Calculator/pull/1), we now want to have a rounded feature to avoid having to dig deep into your pockets 💰 

I've also added leading icon to inputs.

![Capturedecran2024-10-31at18 33 13-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/823274a0-1973-46fe-839b-cc8e51a8c058)
